### PR TITLE
fix(security): pin GitHub Actions to commit SHA + add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      days: 7
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      days: 7

--- a/.github/workflows/active-record-multi-tenant-tests.yml
+++ b/.github/workflows/active-record-multi-tenant-tests.yml
@@ -14,11 +14,11 @@ jobs:
   static-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1
         with:
           ruby-version: 3.2
           bundler-cache: true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Rubocop static code analysis
         run: |
           gem install rubocop
@@ -26,10 +26,10 @@ jobs:
   doc_checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
         python-version: 3.9
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Install python dependencies
       run: |
         pip install -r docs/requirements.txt
@@ -71,12 +71,12 @@ jobs:
        APPRAISAL: ${{ matrix.appraisal }}
        CITUS_VERSION: ${{ matrix.citus_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Start Citus Database environment
         run: docker compose up -d
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -85,4 +85,4 @@ jobs:
         run: bundle exec rake spec
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3


### PR DESCRIPTION
## 変更内容

### GitHub Actions SHA固定
ワークフロー内の `uses:` をコミットSHAで固定します。

| Action | Before | After |
|--------|--------|-------|
| `ruby/setup-ruby` | `@v1` | `@0cb964fd540e0a24c900370abf38a33466142735` |
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/setup-python` | `@v4` | `@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c` |
| `codecov/codecov-action` | `@v3` | `@ab904c41d6ece82784817410c45d8b8c02684457` |

### Dependabot 設定追加
- `cooldown: days: 7` でクールダウン設定済み
- `package-ecosystem: github-actions` で GitHub Actions の自動更新を有効化

## 目的
サプライチェーン攻撃対策